### PR TITLE
Add support for localization

### DIFF
--- a/packages/react-tweet/readme.md
+++ b/packages/react-tweet/readme.md
@@ -72,6 +72,7 @@ Fetches and renders the tweet. It accepts the following props:
 - **fallback** - `ReactNode`: The fallback component to render while the tweet is loading. Defaults to `TweetSkeleton`.
 - **onError** - `(error?: any) => any`: The returned error will be sent to the `TweetNotFound` component.
 - **components** - `TweetComponents`: Components to replace the default tweet components. See the [custom tweet components](#custom-tweet-components) section for more details.
+- **locales** - `Locales`: Locales to replace the default locales.
 
 If the environment where `Tweet` is used does not support React Server Components then it will work with [SWR](https://swr.vercel.app/) instead and the tweet will be fetched from `https://react-tweet.vercel.app/api/tweet/:id`, which is CORS friendly.
 
@@ -95,6 +96,7 @@ Renders a tweet. It accepts the following props:
 
 - **tweet** - `Tweet`: the tweet data, as returned by `getTweet`. Required.
 - **components** - `TweetComponents`: Components to replace the default tweet components. See the [custom tweet components](#custom-tweet-components) section for more details.
+- **locales** - `Locales`: Locales to replace the default locales.
 
 ### `TweetSkeleton`
 

--- a/packages/react-tweet/src/embedded-tweet.tsx
+++ b/packages/react-tweet/src/embedded-tweet.tsx
@@ -1,4 +1,5 @@
 import type { Tweet } from './api/index.js'
+import { type Locales, defaultLocales } from './locales.js'
 import type { TweetComponents } from './components.js'
 import { TweetContainer } from './tweet-container.js'
 import { TweetHeader } from './tweet-header.js'
@@ -12,18 +13,19 @@ import { TweetReplies } from './tweet-replies.js'
 type Props = {
   tweet: Tweet
   components?: Omit<TweetComponents, 'TweetNotFound'>
+  locales?: Locales
 }
 
-export const EmbeddedTweet = ({ tweet, components }: Props) => (
+export const EmbeddedTweet = ({ tweet, components, locales = defaultLocales }: Props) => (
   <TweetContainer>
-    <TweetHeader tweet={tweet} components={components} />
-    {tweet.in_reply_to_status_id_str && <TweetInReplyTo tweet={tweet} />}
+    <TweetHeader tweet={tweet} components={components} locales={locales.header} />
+    {tweet.in_reply_to_status_id_str && <TweetInReplyTo tweet={tweet} locales={locales.tweet.inReply} />}
     <TweetBody tweet={tweet} />
     {tweet.mediaDetails?.length ? (
-      <TweetMedia tweet={tweet} components={components} />
+      <TweetMedia tweet={tweet} components={components} locales={locales.tweet.media} />
     ) : null}
-    <TweetInfo tweet={tweet} />
-    <TweetActions tweet={tweet} />
-    <TweetReplies tweet={tweet} />
+    <TweetInfo tweet={tweet} locales={locales.tweet.info} />
+    <TweetActions tweet={tweet} locales={locales.actions} />
+    <TweetReplies tweet={tweet} locales={locales.readMore} />
   </TweetContainer>
 )

--- a/packages/react-tweet/src/locales.ts
+++ b/packages/react-tweet/src/locales.ts
@@ -1,0 +1,68 @@
+import format from 'date-fns/format/index.js'
+import { formatNumber } from './utils.js'
+
+export const defaultLocales = {
+  actions: {
+    copy: {
+      ariaLabel: 'Copy link',
+      text: 'Copy link',
+      altText: 'Copy link to Tweet',
+      done: 'Copied!',
+    },
+    like: {
+      ariaLabel: (favoriteCount: number) => `Like. This Tweet has ${favoriteCount} likes`,
+      text: (favoriteCount: number) => formatNumber(favoriteCount),
+    },
+    reply: {
+      ariaLabel: 'Reply to this Tweet on Twitter',
+      text: 'Reply'
+    },
+  },
+  header: {
+    author: {
+      verified: {
+        ariaLabel: 'Verified account',
+      },
+    },
+    authorMeta: {
+      followText: 'Follow',
+    },
+    brand: {
+      ariaLabel: 'View on Twitter',
+    },
+  },
+  tweet: {
+    inReply: {
+      text: (screenName?: string) => `Replying to @${screenName}`,
+    },
+    info: {
+      ariaLabel: 'Twitter for Websites, Ads Information and Privacy',
+      createdAt: {
+        ariaLabel: (createdAt: Date) => format(createdAt, 'h:mm a · MMM d, y'),
+        text: (createdAt: Date) => format(createdAt, 'h:mm a · MMM d, y'),
+      },
+    },
+    media: {
+      video: {
+        play: {
+          ariaLabel: 'View video on Twitter',
+        },
+      },
+    },
+  },
+  notFound: {
+    heading: (_error: any) => 'Tweet not found',
+    text: (_error: any) => 'Tweet not found',
+  },
+  readMore: {
+    text: (conversationCount: number) => {
+      if (conversationCount === 0) return 'Read more on Twitter'
+
+      return conversationCount === 1
+        ? `Read ${formatNumber(conversationCount)} reply`
+        : `Read ${formatNumber(conversationCount)} replies`
+    },
+  },
+}
+
+export type Locales = typeof defaultLocales;

--- a/packages/react-tweet/src/swr.tsx
+++ b/packages/react-tweet/src/swr.tsx
@@ -2,6 +2,7 @@
 
 import useSWR from 'swr'
 import { Tweet as ITweet, TwitterApiError } from './api/index.js'
+import { type Locales, defaultLocales } from './locales.js'
 import type { TweetProps } from './tweet.js'
 import { defaultComponents } from './components.js'
 import { EmbeddedTweet } from './embedded-tweet.js'
@@ -29,6 +30,7 @@ export const Tweet = ({
   apiUrl,
   fallback = <TweetSkeleton />,
   components,
+  locales = defaultLocales,
   onError,
 }: TweetProps) => {
   const { data, error, isLoading } = useSWR<ITweet>(
@@ -45,8 +47,8 @@ export const Tweet = ({
   if (error || !data) {
     const TweetNotFound =
       components?.TweetNotFound || defaultComponents.TweetNotFound
-    return <TweetNotFound error={onError ? onError(error) : error} />
+    return <TweetNotFound error={onError ? onError(error) : error} locales={locales.notFound} />
   }
 
-  return <EmbeddedTweet tweet={data} components={components} />
+  return <EmbeddedTweet tweet={data} components={components} locales={locales} />
 }

--- a/packages/react-tweet/src/tweet-actions-copy.tsx
+++ b/packages/react-tweet/src/tweet-actions-copy.tsx
@@ -13,7 +13,7 @@ type Props = {
 
 export const TweetActionsCopy = ({ tweet, locales }: Props) => {
   const [copied, setCopied] = useState(false)
-  const [copyAllText, setCopyAltText] = useState(false)
+  const [copyAltText, setCopyAltText] = useState(false)
   const handleCopy = () => {
     navigator.clipboard.writeText(getTweetUrl(tweet))
     setCopied(true)
@@ -53,7 +53,7 @@ export const TweetActionsCopy = ({ tweet, locales }: Props) => {
         )}
       </div>
       <span className={s.copyText}>
-        {copied ? locales.done : copyAllText ? locales.altText : locales.text}
+        {copied ? locales.done : copyAltText ? locales.altText : locales.text}
       </span>
     </button>
   )

--- a/packages/react-tweet/src/tweet-actions-copy.tsx
+++ b/packages/react-tweet/src/tweet-actions-copy.tsx
@@ -2,10 +2,16 @@
 
 import { useState, useEffect } from 'react'
 import type { Tweet } from './api/index.js'
+import type { Locales } from './locales.js'
 import { getTweetUrl } from './utils.js'
 import s from './tweet-actions.module.css'
 
-export const TweetActionsCopy = ({ tweet }: { tweet: Tweet }) => {
+type Props = {
+  tweet: Tweet
+  locales: Locales['actions']['copy']
+}
+
+export const TweetActionsCopy = ({ tweet, locales }: Props) => {
   const [copied, setCopied] = useState(false)
   const [copyAllText, setCopyAltText] = useState(false)
   const handleCopy = () => {
@@ -28,7 +34,7 @@ export const TweetActionsCopy = ({ tweet }: { tweet: Tweet }) => {
     <button
       type="button"
       className={s.copy}
-      aria-label="Copy link"
+      aria-label={locales.ariaLabel}
       onClick={handleCopy}
     >
       <div className={s.copyIconWrapper}>
@@ -47,7 +53,7 @@ export const TweetActionsCopy = ({ tweet }: { tweet: Tweet }) => {
         )}
       </div>
       <span className={s.copyText}>
-        {copied ? 'Copied!' : copyAllText ? 'Copy link to Tweet' : 'Copy link'}
+        {copied ? locales.done : copyAllText ? locales.altText : locales.text}
       </span>
     </button>
   )

--- a/packages/react-tweet/src/tweet-actions.tsx
+++ b/packages/react-tweet/src/tweet-actions.tsx
@@ -1,11 +1,15 @@
 import type { Tweet } from './api/index.js'
-import { getLikeUrl, getReplyUrl, formatNumber } from './utils.js'
+import type { Locales } from './locales.js'
+import { getLikeUrl, getReplyUrl } from './utils.js'
 import { TweetActionsCopy } from './tweet-actions-copy.js'
 import s from './tweet-actions.module.css'
 
-export const TweetActions = ({ tweet }: { tweet: Tweet }) => {
-  const favoriteCount = formatNumber(tweet.favorite_count)
+type Props = {
+  tweet: Tweet
+  locales: Locales['actions']
+}
 
+export const TweetActions = ({ tweet, locales }: Props) => {
   return (
     <div className={s.actions}>
       <a
@@ -13,7 +17,7 @@ export const TweetActions = ({ tweet }: { tweet: Tweet }) => {
         href={getLikeUrl(tweet)}
         target="_blank"
         rel="noopener noreferrer"
-        aria-label={`Like. This Tweet has ${favoriteCount} likes`}
+        aria-label={locales.like.ariaLabel(tweet.favorite_count)}
       >
         <div className={s.likeIconWrapper}>
           <svg viewBox="0 0 24 24" className={s.likeIcon} aria-hidden="true">
@@ -22,14 +26,14 @@ export const TweetActions = ({ tweet }: { tweet: Tweet }) => {
             </g>
           </svg>
         </div>
-        <span className={s.likeCount}>{favoriteCount}</span>
+        <span className={s.likeCount}>{locales.like.text(tweet.favorite_count)}</span>
       </a>
       <a
         className={s.reply}
         href={getReplyUrl(tweet)}
         target="_blank"
         rel="noopener noreferrer"
-        aria-label="Reply to this Tweet on Twitter"
+        aria-label={locales.reply.ariaLabel}
       >
         <div className={s.replyIconWrapper}>
           <svg viewBox="0 0 24 24" className={s.replyIcon} aria-hidden="true">
@@ -38,9 +42,9 @@ export const TweetActions = ({ tweet }: { tweet: Tweet }) => {
             </g>
           </svg>
         </div>
-        <span className={s.replyText}>Reply</span>
+        <span className={s.replyText}>{locales.reply.text}</span>
       </a>
-      <TweetActionsCopy tweet={tweet} />
+      <TweetActionsCopy tweet={tweet} locales={locales.copy} />
     </div>
   )
 }

--- a/packages/react-tweet/src/tweet-header.tsx
+++ b/packages/react-tweet/src/tweet-header.tsx
@@ -1,15 +1,17 @@
 import clsx from 'clsx'
 import type { Tweet } from './api/index.js'
 import { getFollowUrl, getUserUrl } from './utils.js'
+import type { Locales } from './locales.js'
 import { type TweetComponents, defaultComponents } from './components.js'
 import s from './tweet-header.module.css'
 
 type Props = {
   tweet: Tweet
   components?: TweetComponents
+  locales: Locales['header']
 }
 
-export const TweetHeader = ({ tweet, components }: Props) => {
+export const TweetHeader = ({ tweet, components, locales }: Props) => {
   const url = getUserUrl(tweet)
   const AvatarImg = components?.AvatarImg ?? defaultComponents.AvatarImg
 
@@ -53,7 +55,7 @@ export const TweetHeader = ({ tweet, components }: Props) => {
               >
                 <svg
                   viewBox="0 0 24 24"
-                  aria-label="Verified account"
+                  aria-label={locales.author.verified.ariaLabel}
                   role="img"
                   className={s.authorVerifiedIcon}
                 >
@@ -83,7 +85,7 @@ export const TweetHeader = ({ tweet, components }: Props) => {
               target="_blank"
               rel="noopener noreferrer"
             >
-              Follow
+              {locales.authorMeta.followText}
             </a>
           </div>
         </div>
@@ -93,7 +95,7 @@ export const TweetHeader = ({ tweet, components }: Props) => {
         className={s.brand}
         target="_blank"
         rel="noopener noreferrer"
-        aria-label="View on Twitter"
+        aria-label={locales.brand.ariaLabel}
       >
         <svg viewBox="0 0 24 24" aria-hidden="true" className={s.twitterIcon}>
           <g>

--- a/packages/react-tweet/src/tweet-in-reply-to.tsx
+++ b/packages/react-tweet/src/tweet-in-reply-to.tsx
@@ -1,14 +1,20 @@
 import type { Tweet } from './api/index.js'
+import type { Locales } from './locales.js'
 import { getInReplyToUrl } from './utils.js'
 import s from './tweet-in-reply-to.module.css'
 
-export const TweetInReplyTo = ({ tweet }: { tweet: Tweet }) => (
+type Props = {
+  tweet: Tweet
+  locales: Locales['tweet']['inReply']
+}
+
+export const TweetInReplyTo = ({ tweet, locales }: Props) => (
   <a
     href={getInReplyToUrl(tweet)}
     className={s.root}
     target="_blank"
     rel="noopener noreferrer"
   >
-    Replying to @{tweet.in_reply_to_screen_name}
+    {locales.text(tweet.in_reply_to_screen_name)}
   </a>
 )

--- a/packages/react-tweet/src/tweet-info-created-at.tsx
+++ b/packages/react-tweet/src/tweet-info-created-at.tsx
@@ -1,12 +1,17 @@
 'use client'
 
-import format from 'date-fns/format/index.js'
 import type { Tweet } from './api/index.js'
+import type { Locales } from './locales.js'
 import { getTweetUrl } from './utils.js'
 import useMounted from './lib/use-mounted.js'
 import s from './tweet-info-created-at.module.css'
 
-export const TweetInfoCreatedAt = ({ tweet }: { tweet: Tweet }) => {
+type Props = {
+  tweet: Tweet
+  locales: Locales['tweet']['info']['createdAt']
+}
+
+export const TweetInfoCreatedAt = ({ tweet, locales }: Props) => {
   const mounted = useMounted()
   const createdAt =
     typeof window !== 'undefined' && mounted ? new Date(tweet.created_at) : null
@@ -17,10 +22,10 @@ export const TweetInfoCreatedAt = ({ tweet }: { tweet: Tweet }) => {
       href={getTweetUrl(tweet)}
       target="_blank"
       rel="noopener noreferrer"
-      aria-label={format(createdAt, 'h:mm a · MMM d, y')}
+      aria-label={locales.ariaLabel(createdAt)}
     >
       <time dateTime={createdAt.toISOString()}>
-        {format(createdAt, 'h:mm a · MMM d, y')}
+        {locales.text(createdAt)}
       </time>
     </a>
   )

--- a/packages/react-tweet/src/tweet-info.tsx
+++ b/packages/react-tweet/src/tweet-info.tsx
@@ -1,17 +1,23 @@
 import type { Tweet } from './api/index.js'
+import type { Locales } from './locales.js'
 import { TweetInfoCreatedAt } from './tweet-info-created-at.js'
 import s from './tweet-info.module.css'
 
-export const TweetInfo = ({ tweet }: { tweet: Tweet }) => {
+type Props = {
+  tweet: Tweet
+  locales: Locales['tweet']['info']
+}
+
+export const TweetInfo = ({ tweet, locales }: Props) => {
   return (
     <div className={s.info}>
-      <TweetInfoCreatedAt tweet={tweet} />
+      <TweetInfoCreatedAt tweet={tweet} locales={locales.createdAt} />
       <a
         className={s.infoLink}
         href="https://help.twitter.com/en/twitter-for-websites-ads-info-and-privacy"
         target="_blank"
         rel="noopener noreferrer"
-        aria-label="Twitter for Websites, Ads Information and Privacy"
+        aria-label={locales.ariaLabel}
       >
         <svg viewBox="0 0 24 24" aria-hidden="true" className={s.infoIcon}>
           <g>

--- a/packages/react-tweet/src/tweet-media-video.tsx
+++ b/packages/react-tweet/src/tweet-media-video.tsx
@@ -2,15 +2,17 @@
 
 import { useState, useMemo } from 'react'
 import type { MediaAnimatedGif, MediaVideo } from './api/index.js'
+import type { Locales } from './locales.js'
 import { getMediaUrl } from './utils.js'
 import mediaStyles from './tweet-media.module.css'
 import s from './tweet-media-video.module.css'
 
 type Props = {
   media: MediaAnimatedGif | MediaVideo
+  locales: Locales['tweet']['media']['video']
 }
 
-export const TweetMediaVideo = ({ media }: Props) => {
+export const TweetMediaVideo = ({ media, locales }: Props) => {
   const [playButton, setPlayButton] = useState(true)
   const { variants } = media.video_info
   const mp4Video = useMemo(() => {
@@ -40,7 +42,7 @@ export const TweetMediaVideo = ({ media }: Props) => {
         <button
           type="button"
           className={s.videoButton}
-          aria-label="View video on Twitter"
+          aria-label={locales.play.ariaLabel}
           onClick={(e) => {
             const video = e.currentTarget.previousSibling as HTMLMediaElement
 

--- a/packages/react-tweet/src/tweet-media.tsx
+++ b/packages/react-tweet/src/tweet-media.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx'
 import type { Tweet } from './api/index.js'
+import type { Locales } from './locales.js'
 import { getMediaUrl, getTweetUrl } from './utils.js'
 import { type TweetComponents, defaultComponents } from './components.js'
 import { TweetMediaVideo } from './tweet-media-video.js'
@@ -8,9 +9,10 @@ import s from './tweet-media.module.css'
 type Props = {
   tweet: Tweet
   components?: TweetComponents
+  locales: Locales['tweet']['media']
 }
 
-export const TweetMedia = ({ tweet, components }: Props) => {
+export const TweetMedia = ({ tweet, components, locales }: Props) => {
   const length = tweet.mediaDetails?.length ?? 0
   const MediaImg = components?.MediaImg ?? defaultComponents.MediaImg
 
@@ -43,7 +45,7 @@ export const TweetMedia = ({ tweet, components }: Props) => {
             </a>
           ) : (
             <div key={media.media_url_https} className={s.mediaContainer}>
-              <TweetMediaVideo media={media} />
+              <TweetMediaVideo media={media} locales={locales.video} />
             </div>
           )
         )}

--- a/packages/react-tweet/src/tweet-not-found.tsx
+++ b/packages/react-tweet/src/tweet-not-found.tsx
@@ -1,15 +1,17 @@
+import type { Locales } from './locales.js'
 import { TweetContainer } from './tweet-container.js'
 import styles from './tweet-not-found.module.css'
 
 type Props = {
   error?: any
+  locales: Locales['notFound']
 }
 
-export const TweetNotFound = (_props: Props) => (
+export const TweetNotFound = ({ error, locales }: Props) => (
   <TweetContainer>
     <div className={styles.root}>
-      <h3>Tweet not found</h3>
-      <p>The embedded tweet could not be found…</p>
+      <h3>{locales.heading(error)}</h3>
+      <p>{locales.text(error)}</p>
     </div>
   </TweetContainer>
 )

--- a/packages/react-tweet/src/tweet-replies.tsx
+++ b/packages/react-tweet/src/tweet-replies.tsx
@@ -1,17 +1,14 @@
-import { useMemo } from 'react'
 import type { Tweet } from './api/index.js'
-import { getTweetUrl, formatNumber } from './utils.js'
+import type { Locales } from './locales.js'
+import { getTweetUrl } from './utils.js'
 import s from './tweet-replies.module.css'
 
-export const TweetReplies = ({ tweet }: { tweet: Tweet }) => {
-  const repliesLinkText = useMemo(() => {
-    if (tweet.conversation_count === 0) return 'Read more on Twitter'
+type Props = {
+  tweet: Tweet
+  locales: Locales['readMore']
+}
 
-    return tweet.conversation_count === 1
-      ? `Read ${formatNumber(tweet.conversation_count)} reply`
-      : `Read ${formatNumber(tweet.conversation_count)} replies`
-  }, [tweet.conversation_count])
-
+export const TweetReplies = ({ tweet, locales }: Props) => {
   return (
     <div className={s.replies}>
       <a
@@ -20,7 +17,7 @@ export const TweetReplies = ({ tweet }: { tweet: Tweet }) => {
         target="_blank"
         rel="noopener noreferrer"
       >
-        <span className={s.text}>{repliesLinkText}</span>
+        <span className={s.text}>{locales.text(tweet.conversation_count)}</span>
       </a>
     </div>
   )

--- a/packages/react-tweet/src/tweet.tsx
+++ b/packages/react-tweet/src/tweet.tsx
@@ -1,5 +1,6 @@
 import { Suspense, type ReactNode } from 'react'
 import { getTweet } from './api/index.js'
+import { type Locales, defaultLocales } from './locales.js'
 import { defaultComponents, TweetComponents } from './components.js'
 import { EmbeddedTweet } from './embedded-tweet.js'
 import { TweetSkeleton } from './tweet-skeleton.js'
@@ -7,6 +8,7 @@ import { TweetSkeleton } from './tweet-skeleton.js'
 export type TweetProps = {
   fallback?: ReactNode
   components?: TweetComponents
+  locales?: Locales
   onError?(error: any): any
 } & (
   | { id?: string; apiUrl: string | undefined }
@@ -15,7 +17,7 @@ export type TweetProps = {
 
 type Props = Omit<TweetProps, 'fallback'>
 
-const TweetContent = async ({ id, components, onError }: Props) => {
+const TweetContent = async ({ id, components, onError, locales = defaultLocales}: Props) => {
   let error
   const tweet = id
     ? await getTweet(id).catch((err) => {
@@ -31,10 +33,10 @@ const TweetContent = async ({ id, components, onError }: Props) => {
   if (!tweet) {
     const TweetNotFound =
       components?.TweetNotFound || defaultComponents.TweetNotFound
-    return <TweetNotFound error={error} />
+    return <TweetNotFound error={error} locales={locales.notFound} />
   }
 
-  return <EmbeddedTweet tweet={tweet} components={components} />
+  return <EmbeddedTweet tweet={tweet} components={components} locales={locales} />
 }
 
 export const Tweet = ({


### PR DESCRIPTION
Since the UI wording was only available in English, I added `props.locales` to allow developers to override that wording.

*I've purposely ignored Prettier rules because they would have increased the number of differences.*