### PR TITLE
fix position twitter icon for dir=rtl

### DIFF
--- a/packages/react-tweet/src/twitter-theme/tweet-header.module.css
+++ b/packages/react-tweet/src/twitter-theme/tweet-header.module.css
@@ -93,7 +93,7 @@
 }
 
 .brand {
-  margin-left: auto;
+  margin-inline-start: auto;
 }
 
 .twitterIcon {


### PR DESCRIPTION
Hello maintainers,

The margin-left property was changed to margin-inline-start to have proper position of the Twitter icon on websites with dir attribute set to rtl direction. This change resolves the visual inconsistencies. The modification has been tested and does not impact left-to-right websites.