### PR TITLE
Fix regression in media layout with multiple images

### DIFF
--- a/packages/react-tweet/src/twitter-theme/tweet-media.module.css
+++ b/packages/react-tweet/src/twitter-theme/tweet-media.module.css
@@ -8,10 +8,7 @@
 .mediaWrapper {
   display: grid;
   grid-auto-rows: 1fr;
-  position: absolute;
-  top: 0px;
-  left: 0px;
-  bottom: 0px;
+  gap: 2px;
   height: 100%;
   width: 100%;
 }

--- a/packages/react-tweet/src/twitter-theme/tweet-media.tsx
+++ b/packages/react-tweet/src/twitter-theme/tweet-media.tsx
@@ -1,10 +1,19 @@
 import { Fragment } from 'react'
 import clsx from 'clsx'
 import { type EnrichedTweet, getMediaUrl } from '../utils.js'
+import { MediaDetails } from '../api/index.js'
 import type { TwitterComponents } from './types.js'
 import { TweetMediaVideo } from './tweet-media-video.js'
 import { MediaImg } from './media-img.js'
 import s from './tweet-media.module.css'
+
+const getSkeletonStyle = (media: MediaDetails) => ({
+  width: media.type === 'video' ? 'unset' : undefined,
+  paddingBottom: `${Math.max(
+    (100 / media.original_info.width) * media.original_info.height,
+    56.25
+  )}%`,
+})
 
 type Props = {
   tweet: EnrichedTweet
@@ -17,29 +26,16 @@ export const TweetMedia = ({ tweet, components }: Props) => {
 
   return (
     <div className={s.root}>
-      {tweet.mediaDetails?.map((media) => (
-        <Fragment key={media.media_url_https}>
-          <div
-            className={s.skeleton}
-            style={
-              media.type === 'photo'
-                ? {
-                    paddingBottom: `${
-                      (100 / media.original_info.width) *
-                      media.original_info.height
-                    }%`,
-                  }
-                : undefined
-            }
-          />
-          <div
-            className={clsx(
-              s.mediaWrapper,
-              length > 1 && s.grid2Columns,
-              length === 3 && s.grid3,
-              length > 4 && s.grid2x2
-            )}
-          >
+      <div
+        className={clsx(
+          s.mediaWrapper,
+          length > 1 && s.grid2Columns,
+          length === 3 && s.grid3,
+          length > 4 && s.grid2x2
+        )}
+      >
+        {tweet.mediaDetails?.map((media) => (
+          <Fragment key={media.media_url_https}>
             {media.type === 'photo' ? (
               <a
                 key={media.media_url_https}
@@ -48,6 +44,7 @@ export const TweetMedia = ({ tweet, components }: Props) => {
                 target="_blank"
                 rel="noopener noreferrer"
               >
+                <div className={s.skeleton} style={getSkeletonStyle(media)} />
                 <Img
                   src={getMediaUrl(media, 'small')}
                   alt={media.ext_alt_text || 'Image'}
@@ -57,12 +54,13 @@ export const TweetMedia = ({ tweet, components }: Props) => {
               </a>
             ) : (
               <div key={media.media_url_https} className={s.mediaContainer}>
+                <div className={s.skeleton} style={getSkeletonStyle(media)} />
                 <TweetMediaVideo tweet={tweet} media={media} />
               </div>
             )}
-          </div>
-        </Fragment>
-      ))}
+          </Fragment>
+        ))}
+      </div>
     </div>
   )
 }

--- a/packages/react-tweet/src/twitter-theme/tweet-media.tsx
+++ b/packages/react-tweet/src/twitter-theme/tweet-media.tsx
@@ -7,13 +7,22 @@ import { TweetMediaVideo } from './tweet-media-video.js'
 import { MediaImg } from './media-img.js'
 import s from './tweet-media.module.css'
 
-const getSkeletonStyle = (media: MediaDetails) => ({
-  width: media.type === 'video' ? 'unset' : undefined,
-  paddingBottom: `${Math.max(
-    (100 / media.original_info.width) * media.original_info.height,
-    56.25
-  )}%`,
-})
+const getSkeletonStyle = (media: MediaDetails, itemCount: number) => {
+  let paddingBottom = 56.25 // default of 16x9
+
+  // if we only have 1 item, show at original ratio
+  if (itemCount === 1)
+    paddingBottom =
+      (100 / media.original_info.width) * media.original_info.height
+
+  // if we have 2 items, double the default to be 16x9 total
+  if (itemCount === 2) paddingBottom = paddingBottom * 2
+
+  return {
+    width: media.type === 'photo' ? undefined : 'unset',
+    paddingBottom: `${paddingBottom}%`,
+  }
+}
 
 type Props = {
   tweet: EnrichedTweet
@@ -44,7 +53,10 @@ export const TweetMedia = ({ tweet, components }: Props) => {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <div className={s.skeleton} style={getSkeletonStyle(media)} />
+                <div
+                  className={s.skeleton}
+                  style={getSkeletonStyle(media, length)}
+                />
                 <Img
                   src={getMediaUrl(media, 'small')}
                   alt={media.ext_alt_text || 'Image'}
@@ -54,7 +66,10 @@ export const TweetMedia = ({ tweet, components }: Props) => {
               </a>
             ) : (
               <div key={media.media_url_https} className={s.mediaContainer}>
-                <div className={s.skeleton} style={getSkeletonStyle(media)} />
+                <div
+                  className={s.skeleton}
+                  style={getSkeletonStyle(media, length)}
+                />
                 <TweetMediaVideo tweet={tweet} media={media} />
               </div>
             )}


### PR DESCRIPTION
The changes introduced in #99 inadvertently broke the media layouts when there is more than one image present (reported in #101).

The changes presented here will keep with the spirit of making the base theme match Twitter as closely as possible, while also supporting a grid of multiple images.