### PR TITLE
fix: bump author padding

### DIFF
--- a/packages/react-tweet/src/twitter-theme/tweet-header.module.css
+++ b/packages/react-tweet/src/twitter-theme/tweet-header.module.css
@@ -39,7 +39,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  margin: 0 0.25rem;
+  margin: 0 0.5rem;
 }
 .authorLink {
   text-decoration: none;


### PR DESCRIPTION
Use `0.5rem` of spacing instead of `0.25rem`.  See comparison below.

| `0.5rem` Padding (new) | `0.25rem` Padding |
|:---------------:|:--------------:|
| <img width="612" alt="image" src="https://github.com/vercel/react-tweet/assets/1657236/37656c19-9f71-4cd9-8344-dc6e510dc5cc"> | <img width="612" alt="image" src="https://github.com/vercel/react-tweet/assets/1657236/dd29e381-d852-4129-b265-01bbf7bc64f4"> |

