### PR TITLE
Responsive layout in demo apps

### DIFF
--- a/apps/create-react-app/src/app.module.css
+++ b/apps/create-react-app/src/app.module.css
@@ -7,7 +7,6 @@
   padding: 2rem 1rem;
 }
 .main {
-  display: grid;
+  display: flex;
   justify-content: center;
-  grid-template-columns: minmax(max-content, 550px);
 }

--- a/apps/vite-app/src/layout.module.css
+++ b/apps/vite-app/src/layout.module.css
@@ -7,7 +7,6 @@
   padding: 2rem 1rem;
 }
 .main {
-  display: grid;
+  display: flex;
   justify-content: center;
-  grid-template-columns: minmax(max-content, 550px);
 }


### PR DESCRIPTION
Two of the demo apps had layouts that were not allowing the tweet to shrink for small window sizes.

This change brings those two apps into sync with the styles from `apps/next-app` (which handled it well.)

Before:
<img width="430" alt="Screenshot 2023-07-29 at 10 42 10 PM" src="https://github.com/vercel/react-tweet/assets/1395543/4adb1524-d313-4109-b5a4-7be5ebbfc0b8">

After: 
<img width="421" alt="Screenshot 2023-07-29 at 10 42 56 PM" src="https://github.com/vercel/react-tweet/assets/1395543/f1d36a0a-b38f-4452-b221-18231ed5a45e">
