### PR TITLE
Add missing token to api calls to Twitter's CDN

### DIFF
--- a/.changeset/honest-rabbits-swim.md
+++ b/.changeset/honest-rabbits-swim.md
@@ -1,0 +1,5 @@
+---
+'react-tweet': patch
+---
+
+Added token to API requests to Twitter's CDN

--- a/.changeset/honest-rabbits-swim.md
+++ b/.changeset/honest-rabbits-swim.md
@@ -2,4 +2,4 @@
 'react-tweet': patch
 ---
 
-Added token to API requests to Twitter's CDN
+Added missing token to API requests to Twitter's CDN

--- a/.changeset/stupid-nails-eat.md
+++ b/.changeset/stupid-nails-eat.md
@@ -1,5 +1,0 @@
----
-'react-tweet': minor
----
-
-Added quoted tweet support and updated logo

--- a/.changeset/stupid-nails-eat.md
+++ b/.changeset/stupid-nails-eat.md
@@ -1,0 +1,5 @@
+---
+'react-tweet': minor
+---
+
+Added quoted tweet support and updated logo

--- a/packages/react-tweet/src/api/get-tweet.ts
+++ b/packages/react-tweet/src/api/get-tweet.ts
@@ -24,6 +24,12 @@ export class TwitterApiError extends Error {
 
 const TWEET_ID = /^[0-9]+$/
 
+function getToken(id: string) {
+  return ((Number(id) / 1e15) * Math.PI)
+    .toString(6 ** 2)
+    .replace(/(0+|\.)/g, '')
+}
+
 /**
  * Fetches a tweet from the Twitter syndication API.
  */
@@ -46,8 +52,11 @@ export async function getTweet(
       'tfw_follower_count_sunset:true',
       'tfw_tweet_edit_backend:on',
       'tfw_refsrc_session:on',
+      'tfw_fosnr_soft_interventions_enabled:on',
+      'tfw_show_birdwatch_pivots_enabled:on',
       'tfw_show_business_verified_badge:on',
       'tfw_duplicate_scribes_to_settings:on',
+      'tfw_use_profile_image_shape_enabled:on',
       'tfw_show_blue_verified_badge:on',
       'tfw_legacy_timeline_sunset:true',
       'tfw_show_gov_verified_badge:on',
@@ -55,7 +64,8 @@ export async function getTweet(
       'tfw_tweet_edit_frontend:on',
     ].join(';')
   )
-  
+  url.searchParams.set('token', getToken(id))
+
   const res = await fetch(url.toString(), fetchOptions)
   const isJson = res.headers.get('content-type')?.includes('application/json')
   const data = isJson ? await res.json() : undefined


### PR DESCRIPTION
Twitter API calls in https://publish.twitter.com/ include a `token` that I was not including before. I've been noticing that APi calls start returning an empty object `{}` after a while if that token is not added so I looked into their minified code to know how that token is calculated and added that here.