### PR TITLE
Add Hexagon as valid profile_image_shape

### DIFF
--- a/packages/react-tweet/src/api/types/user.ts
+++ b/packages/react-tweet/src/api/types/user.ts
@@ -2,7 +2,7 @@ export interface TweetUser {
   id_str: string
   name: string
   profile_image_url_https: string
-  profile_image_shape: 'Circle' | 'Square'
+  profile_image_shape: 'Circle' | 'Square' | 'Hexagon'
   screen_name: string
   verified: boolean
   verified_type?: 'Business' | 'Government'


### PR DESCRIPTION
I'm not sure if this library should also handle the _styling_ of hexagon avatars, but I think this should be included in the type definitions for package users who are extending components on their own.

![Screen Shot 2023-11-08 at 14 02 26@2x](https://github.com/vercel/react-tweet/assets/1923260/cbe80146-6ecc-4600-88a9-55cfceae827a)
