### PR TITLE
fix text content in media button and replies

### DIFF
--- a/packages/react-tweet/src/twitter-theme/tweet-media-video.tsx
+++ b/packages/react-tweet/src/twitter-theme/tweet-media-video.tsx
@@ -53,7 +53,7 @@ export const TweetMediaVideo = ({ tweet, media }: Props) => {
         <button
           type="button"
           className={s.videoButton}
-          aria-label="View video on Twitter"
+          aria-label="View video on X"
           onClick={(e) => {
             const video = e.currentTarget.previousSibling as HTMLMediaElement
 
@@ -84,7 +84,7 @@ export const TweetMediaVideo = ({ tweet, media }: Props) => {
             target="_blank"
             rel="noopener noreferrer"
           >
-            {playButton ? 'Watch on Twitter' : 'Continue watching on Twitter'}
+            {playButton ? 'Watch on X' : 'Continue watching on X'}
           </a>
         </div>
       )}

--- a/packages/react-tweet/src/twitter-theme/tweet-replies.tsx
+++ b/packages/react-tweet/src/twitter-theme/tweet-replies.tsx
@@ -11,7 +11,7 @@ export const TweetReplies = ({ tweet }: { tweet: EnrichedTweet }) => (
     >
       <span className={s.text}>
         {tweet.conversation_count === 0
-          ? 'Read more on Twitter'
+          ? 'Read more on X'
           : tweet.conversation_count === 1
           ? `Read ${formatNumber(tweet.conversation_count)} reply`
           : `Read ${formatNumber(tweet.conversation_count)} replies`}


### PR DESCRIPTION
Because Twitter rebranded to X, they changed the text button in media content and text in the replay button. My changes will fix the inconsistencies.

https://publish.twitter.com/?query=https%3A%2F%2Ftwitter.com%2Ffararacos%2Fstatus%2F1759956591036555463&widget=Tweet
