### PR TITLE
Set `lang` and `dir` attributes on tweet bodies

### DIFF
--- a/packages/react-tweet/src/twitter-theme/quoted-tweet/quoted-tweet-body.tsx
+++ b/packages/react-tweet/src/twitter-theme/quoted-tweet/quoted-tweet-body.tsx
@@ -4,7 +4,7 @@ import s from './quoted-tweet-body.module.css'
 type Props = { tweet: EnrichedQuotedTweet }
 
 export const QuotedTweetBody = ({ tweet }: Props) => (
-  <p className={s.root}>
+  <p className={s.root} lang={tweet.lang} dir="auto">
     {tweet.entities.map((item, i) => (
       <span key={i} dangerouslySetInnerHTML={{ __html: item.text }} />
     ))}

--- a/packages/react-tweet/src/twitter-theme/tweet-body.tsx
+++ b/packages/react-tweet/src/twitter-theme/tweet-body.tsx
@@ -3,7 +3,7 @@ import { TweetLink } from './tweet-link.js'
 import s from './tweet-body.module.css'
 
 export const TweetBody = ({ tweet }: { tweet: EnrichedTweet }) => (
-  <p className={s.root}>
+  <p className={s.root} lang={tweet.lang} dir="auto">
     {tweet.entities.map((item, i) => {
       switch (item.type) {
         case 'hashtag':


### PR DESCRIPTION
Tweets can be written in various languages. Language metadata is essential for browsers to correctly render multilingual texts because the different language uses different shapes of glyphs for the same Unicode codepoints, and the browsers must select fonts based on the intended language[^1].

Twitter API infers the primary language of each tweet, and this patch sets the `lang` attribute to the inferred language for the tweet bodies. `dir="auto"` is also necessary for proper rendering of texts in the right-to-left languages, such as Arabic, Hebrew, and Persian.

---

This test tweet in Japanese contains several Han characters which present regional variation (See [^1] for details): https://twitter.com/k_hanazuki/status/1803451841684111591

- Without the patch, incorrect glyphs (Chinese variant) are used. Actual rendering results depend on browser/system locale settings (Chrome chooses Chinese font as fallback when the preferred language is only English).
![image](https://github.com/vercel/react-tweet/assets/1135690/8cbc0f91-c0b7-4297-9071-5ffd021b10f5)
- With the patch (correct).
![image](https://github.com/vercel/react-tweet/assets/1135690/c4c21416-b414-4318-8b0c-1aaf73b2cc37)


[^1]: Regarding font selection in CJK languages: <https://heistak.github.io/your-code-displays-japanese-wrong/>