### PR TITLE
export utils

### DIFF
--- a/packages/react-tweet/package.json
+++ b/packages/react-tweet/package.json
@@ -35,6 +35,9 @@
       "index": [
         "src/index"
       ],
+      "utils": [
+        "src/utils"
+      ],
       "api": [
         "src/api/index"
       ],
@@ -47,6 +50,9 @@
       "*": {
         "index": [
           "dist/index.d.ts"
+        ],
+        "utils": [
+          "dist/utils.d.ts"
         ],
         "api": [
           "dist/api/index.d.ts"

--- a/packages/react-tweet/src/utils.ts
+++ b/packages/react-tweet/src/utils.ts
@@ -13,6 +13,8 @@ import type {
   MediaVideo,
 } from './api/index.js'
 
+export  { formatDate } from './date-utils.js'
+
 export type TweetCoreProps = {
   id: string
   onError?(error: any): any


### PR DESCRIPTION
Hi!
I'd like to use api/util functions without React dependency in my non-react project(like https://github.com/ryoppippi/sveltweet)
So I added `utils` export path to package.json