### PR TITLE
chore: update repo from vercel-labs to vercel

### DIFF
--- a/apps/create-react-app/package.json
+++ b/apps/create-react-app/package.json
@@ -2,7 +2,7 @@
   "name": "create-react-app",
   "private": true,
   "license": "MIT",
-  "repository": "https://github.com/vercel-labs/react-tweet.git",
+  "repository": "https://github.com/vercel/react-tweet.git",
   "author": "Luis Alvarez (https://twitter.com/luis_fades)",
   "main": "src/index.js",
   "scripts": {

--- a/apps/custom-tweet-dub/components/tweet/tweet-text.tsx
+++ b/apps/custom-tweet-dub/components/tweet/tweet-text.tsx
@@ -29,7 +29,7 @@ export const TweetText = ({ tweet }: { tweet: EnrichedTweet }) => (
           return
         default:
           // We use `dangerouslySetInnerHTML` to preserve the text encoding.
-          // https://github.com/vercel-labs/react-tweet/issues/29
+          // https://github.com/vercel/react-tweet/issues/29
           return (
             <span key={i} dangerouslySetInnerHTML={{ __html: item.text }} />
           )

--- a/apps/custom-tweet-dub/package.json
+++ b/apps/custom-tweet-dub/package.json
@@ -2,7 +2,7 @@
   "name": "custom-tweet-dub",
   "private": true,
   "license": "MIT",
-  "repository": "https://github.com/vercel-labs/react-tweet.git",
+  "repository": "https://github.com/vercel/react-tweet.git",
   "author": "Luis Alvarez (https://twitter.com/luis_fades)",
   "scripts": {
     "dev": "next dev -p 3005",

--- a/apps/next-app/package.json
+++ b/apps/next-app/package.json
@@ -2,7 +2,7 @@
   "name": "next-app",
   "private": true,
   "license": "MIT",
-  "repository": "https://github.com/vercel-labs/react-tweet.git",
+  "repository": "https://github.com/vercel/react-tweet.git",
   "author": "Luis Alvarez (https://twitter.com/luis_fades)",
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -2,7 +2,7 @@
   "name": "site",
   "private": true,
   "license": "MIT",
-  "repository": "https://github.com/vercel-labs/react-tweet.git",
+  "repository": "https://github.com/vercel/react-tweet.git",
   "author": "Luis Alvarez (https://twitter.com/luis_fades)",
   "description": "Official site and documentation for react-tweet",
   "scripts": {

--- a/apps/site/pages/api-reference.mdx
+++ b/apps/site/pages/api-reference.mdx
@@ -9,11 +9,11 @@ import { getTweet, type Tweet } from 'react-tweet/api'
 
 function getTweet(
   id: string,
-  fetchOptions?: RequestInit
+  fetchOptions?: RequestInit,
 ): Promise<Tweet | undefined>
 ```
 
-Fetches and returns a [`Tweet`](https://github.com/vercel-labs/react-tweet/blob/main/packages/react-tweet/src/api/types/tweet.ts). It accepts the following params:
+Fetches and returns a [`Tweet`](https://github.com/vercel/react-tweet/blob/main/packages/react-tweet/src/api/types/tweet.ts). It accepts the following params:
 
 - **id** - `string`: the tweet ID. For example in `https://twitter.com/chibicode/status/1629307668568633344` the tweet ID is `1629307668568633344`.
 - **fetchOptions** - `RequestInit` (Optional): options to pass to [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/fetch).
@@ -25,7 +25,7 @@ If a tweet is not found it returns `undefined`.
 ```tsx
 function fetchTweet(
   id: string,
-  fetchOptions?: RequestInit
+  fetchOptions?: RequestInit,
 ): Promise<{
   data?: Tweet | undefined
   tombstone?: true | undefined
@@ -33,7 +33,7 @@ function fetchTweet(
 }>
 ```
 
-Fetches and returns a [`Tweet`](https://github.com/vercel-labs/react-tweet/blob/main/packages/react-tweet/src/api/types/tweet.ts) just like [`getTweet`](#gettweet), but it also returns additional information about the tweet:
+Fetches and returns a [`Tweet`](https://github.com/vercel/react-tweet/blob/main/packages/react-tweet/src/api/types/tweet.ts) just like [`getTweet`](#gettweet), but it also returns additional information about the tweet:
 
 - **data** - `Tweet` (Optional): The tweet data.
 - **tombstone** - `true` (Optional): Indicates if the tweet has been made private.
@@ -47,9 +47,9 @@ import { enrichTweet, type EnrichedTweet } from 'react-tweet'
 const enrichTweet: (tweet: Tweet) => EnrichedTweet
 ```
 
-Enriches a [`Tweet`](https://github.com/vercel-labs/react-tweet/blob/main/packages/react-tweet/src/api/types/tweet.ts) as returned by [`getTweet`](#gettweet) with additional data. This is useful to more easily build custom tweet components.
+Enriches a [`Tweet`](https://github.com/vercel/react-tweet/blob/main/packages/react-tweet/src/api/types/tweet.ts) as returned by [`getTweet`](#gettweet) with additional data. This is useful to more easily build custom tweet components.
 
-It returns an [`EnrichedTweet`](https://github.com/vercel-labs/react-tweet/blob/main/packages/react-tweet/src/utils.ts).
+It returns an [`EnrichedTweet`](https://github.com/vercel/react-tweet/blob/main/packages/react-tweet/src/utils.ts).
 
 ## `useTweet`
 
@@ -61,7 +61,7 @@ import { useTweet } from 'react-tweet'
 const useTweet: (
   id?: string,
   apiUrl?: string,
-  fetchOptions?: RequestInit
+  fetchOptions?: RequestInit,
 ) => {
   isLoading: boolean
   data: Tweet | null | undefined

--- a/apps/site/pages/contributing.mdx
+++ b/apps/site/pages/contributing.mdx
@@ -1,7 +1,7 @@
 # Contributing
 
-To contribute, clone the [`react-tweet` repository](https://github.com/vercel-labs/react-tweet) and run the [Next.js test app](/next#running-the-test-app) to start an app locally that uses the [`react-tweet` package](https://github.com/vercel-labs/react-tweet/blob/main/packages/react-tweet). Any changes you make to the package will be reflected in the test app.
+To contribute, clone the [`react-tweet` repository](https://github.com/vercel/react-tweet) and run the [Next.js test app](/next#running-the-test-app) to start an app locally that uses the [`react-tweet` package](https://github.com/vercel/react-tweet/blob/main/packages/react-tweet). Any changes you make to the package will be reflected in the test app.
 
-Once you're done making changes, [submit a pull request](https://github.com/vercel-labs/react-tweet/compare).
+Once you're done making changes, [submit a pull request](https://github.com/vercel/react-tweet/compare).
 
-It's recommended to [open an issue](https://github.com/vercel-labs/react-tweet/issues/new) first before making any major changes to the package so that we can discuss the changes before you start working on them.
+It's recommended to [open an issue](https://github.com/vercel/react-tweet/issues/new) first before making any major changes to the package so that we can discuss the changes before you start working on them.

--- a/apps/site/pages/create-react-app.mdx
+++ b/apps/site/pages/create-react-app.mdx
@@ -20,12 +20,12 @@ You can learn more about `Tweet` in the [Twitter theme docs](/twitter-theme).
 
 ## Running the test app
 
-Clone the [`react-tweet`](https://github.com/vercel-labs/react-tweet) repository and then run the following command:
+Clone the [`react-tweet`](https://github.com/vercel/react-tweet) repository and then run the following command:
 
 ```bash copy
 pnpm install && pnpm dev --filter=create-react-app...
 ```
 
-The app will be up and running at (localhost:3002)[http://localhost:3002] for the [CRA example](https://github.com/vercel-labs/react-tweet/tree/main/apps/create-react-app).
+The app will be up and running at (localhost:3002)[http://localhost:3002] for the [CRA example](https://github.com/vercel/react-tweet/tree/main/apps/create-react-app).
 
-The source code for `react-tweet` is imported from [packages/react-tweet](https://github.com/vercel-labs/react-tweet/tree/main/packages/react-tweet) and any changes you make to it will be reflected in the app immediately.
+The source code for `react-tweet` is imported from [packages/react-tweet](https://github.com/vercel/react-tweet/tree/main/packages/react-tweet) and any changes you make to it will be reflected in the app immediately.

--- a/apps/site/pages/custom-theme.mdx
+++ b/apps/site/pages/custom-theme.mdx
@@ -2,20 +2,20 @@
 
 `react-tweet` exports multiple [utility functions](/api-reference) to help you build your own theme if the default [Twitter theme](/twitter-theme) and its customization options don't work for you or if you simply want to build your own.
 
-To get started, we recommend using the [source for the Twitter theme](https://github.com/vercel-labs/react-tweet/blob/main/packages/react-tweet/src/tweet.tsx) as the base and start customizing from there. Which more precisely is all of the components in the [`react-tweet` package](https://github.com/vercel-labs/react-tweet/blob/main/packages/react-tweet):
+To get started, we recommend using the [source for the Twitter theme](https://github.com/vercel/react-tweet/blob/main/packages/react-tweet/src/tweet.tsx) as the base and start customizing from there. Which more precisely is all of the components in the [`react-tweet` package](https://github.com/vercel/react-tweet/blob/main/packages/react-tweet):
 
-- [`src/tweet.tsx`](https://github.com/vercel-labs/react-tweet/blob/main/packages/react-tweet/src/tweet.tsx): Exports the async `Tweet` component that fetches the tweet data and renders the tweet. This is a [React Server Component](https://react.dev/blog/2023/03/22/react-labs-what-we-have-been-working-on-march-2023#react-server-components).
-- [`src/twitter-theme/*.tsx`](https://github.com/vercel-labs/react-tweet/blob/main/packages/react-tweet/src/twitter-theme): All the components that make up the theme.
-- [`src/swr.tsx`](https://github.com/vercel-labs/react-tweet/blob/main/packages/react-tweet/src/swr.tsx): Exports the `Tweet` component but it uses [SWR](https://swr.vercel.app/) to fetch the tweet client-side. This is useful if React Server Components are not supported by your React environment.
+- [`src/tweet.tsx`](https://github.com/vercel/react-tweet/blob/main/packages/react-tweet/src/tweet.tsx): Exports the async `Tweet` component that fetches the tweet data and renders the tweet. This is a [React Server Component](https://react.dev/blog/2023/03/22/react-labs-what-we-have-been-working-on-march-2023#react-server-components).
+- [`src/twitter-theme/*.tsx`](https://github.com/vercel/react-tweet/blob/main/packages/react-tweet/src/twitter-theme): All the components that make up the theme.
+- [`src/swr.tsx`](https://github.com/vercel/react-tweet/blob/main/packages/react-tweet/src/swr.tsx): Exports the `Tweet` component but it uses [SWR](https://swr.vercel.app/) to fetch the tweet client-side. This is useful if React Server Components are not supported by your React environment.
 
-You can see a custom theme in action by looking at our [custom-tweet-dub](https://github.com/vercel-labs/react-tweet/blob/main/apps/custom-tweet-dub) example.
+You can see a custom theme in action by looking at our [custom-tweet-dub](https://github.com/vercel/react-tweet/blob/main/apps/custom-tweet-dub) example.
 
 ## Publishing your theme
 
 We recommend you follow the same patterns of the Twitter theme before publishing your theme:
 
 - Use the props defined by the `TweetProps` type in your Tweet component.
-- Support the CSS theme features shown in [Toggling theme manually](/#toggling-theme-manually). You can use the [`base.css`](https://github.com/vercel-labs/react-tweet/blob/main/packages/react-tweet/src/twitter-theme/theme.css) file from the Twitter theme as reference.
+- Support the CSS theme features shown in [Toggling theme manually](/#toggling-theme-manually). You can use the [`base.css`](https://github.com/vercel/react-tweet/blob/main/packages/react-tweet/src/twitter-theme/theme.css) file from the Twitter theme as reference.
 - Support both SWR and React Server Components as explained below.
 
 When you use `react-tweet` we tell the builder which `Tweet` component to use with `exports` in `package.json`:

--- a/apps/site/pages/next.mdx
+++ b/apps/site/pages/next.mdx
@@ -45,7 +45,7 @@ import { getTweet as _getTweet } from 'react-tweet/api'
 const getTweet = unstable_cache(
   async (id: string) => _getTweet(id),
   ['tweet'],
-  { revalidate: 3600 * 24 }
+  { revalidate: 3600 * 24 },
 )
 
 const TweetPage = async ({ id }: { id: string }) => {
@@ -148,13 +148,13 @@ export default function Page() {
 
 ## Running the test app
 
-Clone the [`react-tweet`](https://github.com/vercel-labs/react-tweet) repository and then run the following command:
+Clone the [`react-tweet`](https://github.com/vercel/react-tweet) repository and then run the following command:
 
 ```bash copy
 pnpm install && pnpm dev --filter=next-app...
 ```
 
-The app will be up and running at http://localhost:3001 for the [Next.js app example](https://github.com/vercel-labs/react-tweet/tree/main/apps/next-app).
+The app will be up and running at http://localhost:3001 for the [Next.js app example](https://github.com/vercel/react-tweet/tree/main/apps/next-app).
 
 The app shows the usage of `react-tweet` in different scenarios:
 
@@ -166,4 +166,4 @@ The app shows the usage of `react-tweet` in different scenarios:
 - [localhost:3001/light/cache/1629307668568633344](http://localhost:3001/light/suspense/1629307668568633344) renders the tweet while caching the tweet data with [`unstable_cache`](https://nextjs.org/docs/app/api-reference/functions/unstable_cache).
 - [localhost:3001/light/vercel-kv/1629307668568633344](http://localhost:3001/light/suspense/1629307668568633344) renders the tweet while caching the tweet data with [Vercel KV](https://vercel.com/docs/storage/vercel-kv).
 
-The source code for `react-tweet` is imported from [packages/react-tweet](https://github.com/vercel-labs/react-tweet/tree/main/packages/react-tweet) and any changes you make to it will be reflected in the app immediately.
+The source code for `react-tweet` is imported from [packages/react-tweet](https://github.com/vercel/react-tweet/tree/main/packages/react-tweet) and any changes you make to it will be reflected in the app immediately.

--- a/apps/site/pages/vite.mdx
+++ b/apps/site/pages/vite.mdx
@@ -18,17 +18,17 @@ You can learn more about `Tweet` in the [Twitter theme docs](/twitter-theme).
 
 ## Running the test app
 
-Clone the [`react-tweet`](https://github.com/vercel-labs/react-tweet) repository and then run the following command:
+Clone the [`react-tweet`](https://github.com/vercel/react-tweet) repository and then run the following command:
 
 ```bash copy
 pnpm install && pnpm dev --filter=vite-app...
 ```
 
-The app will be up and running at http://localhost:5173 for the [Vite app example](https://github.com/vercel-labs/react-tweet/tree/main/apps/vite-app).
+The app will be up and running at http://localhost:5173 for the [Vite app example](https://github.com/vercel/react-tweet/tree/main/apps/vite-app).
 
 The app shows the usage of `react-tweet` in different scenarios:
 
 - [localhost:5173/](http://localhost:5173) renders a single tweet.
 - [localhost:5173/tweet/1629307668568633344](http://localhost:5173/tweet/1629307668568633344) renders dynamic tweets with SWR. `Tweet` already uses SWR and this page shows how to implement it manually.
 
-The source code for `react-tweet` is imported from [packages/react-tweet](https://github.com/vercel-labs/react-tweet/tree/main/packages/react-tweet) and any changes you make to it will be reflected in the app immediately.
+The source code for `react-tweet` is imported from [packages/react-tweet](https://github.com/vercel/react-tweet/tree/main/packages/react-tweet) and any changes you make to it will be reflected in the app immediately.

--- a/apps/site/theme.config.tsx
+++ b/apps/site/theme.config.tsx
@@ -37,9 +37,9 @@ const config: DocsThemeConfig = {
     )
   },
   project: {
-    link: 'https://github.com/vercel-labs/react-tweet',
+    link: 'https://github.com/vercel/react-tweet',
   },
-  docsRepositoryBase: 'https://github.com/vercel-labs/react-tweet',
+  docsRepositoryBase: 'https://github.com/vercel/react-tweet',
   editLink: {
     text: 'Edit this page on GitHub →',
   },

--- a/apps/vite-app/package.json
+++ b/apps/vite-app/package.json
@@ -2,7 +2,7 @@
   "name": "vite-app",
   "private": true,
   "license": "MIT",
-  "repository": "https://github.com/vercel-labs/react-tweet.git",
+  "repository": "https://github.com/vercel/react-tweet.git",
   "author": "Luis Alvarez (https://twitter.com/luis_fades)",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "repository": "https://github.com/vercel-labs/react-tweet.git",
+  "repository": "https://github.com/vercel/react-tweet.git",
   "license": "MIT",
   "private": true,
   "author": "Luis Alvarez (https://twitter.com/luis_fades)",

--- a/packages/react-tweet/package.json
+++ b/packages/react-tweet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-tweet",
   "version": "3.2.2",
-  "repository": "https://github.com/vercel-labs/react-tweet.git",
+  "repository": "https://github.com/vercel/react-tweet.git",
   "author": "Luis Alvarez (https://twitter.com/luis_fades)",
   "scripts": {
     "build": "pnpm build:swc && pnpm types",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/vercel-labs/react-tweet/issues"
+    "url": "https://github.com/vercel/react-tweet/issues"
   },
   "sideEffects": [
     "./dist/twitter-theme/tweet-container.js"

--- a/packages/react-tweet/src/twitter-theme/tweet-body.tsx
+++ b/packages/react-tweet/src/twitter-theme/tweet-body.tsx
@@ -21,7 +21,7 @@ export const TweetBody = ({ tweet }: { tweet: EnrichedTweet }) => (
           return
         default:
           // We use `dangerouslySetInnerHTML` to preserve the text encoding.
-          // https://github.com/vercel-labs/react-tweet/issues/29
+          // https://github.com/vercel/react-tweet/issues/29
           return (
             <span key={i} dangerouslySetInnerHTML={{ __html: item.text }} />
           )


### PR DESCRIPTION
I noticed that pretty much every repo URL was still referencing `vercel-labs` even though this repo was moved over to `vercel`.